### PR TITLE
Add Transaction Events

### DIFF
--- a/src/main/java/org/jarling/models/hooks/DirectDebitCreditEvent.java
+++ b/src/main/java/org/jarling/models/hooks/DirectDebitCreditEvent.java
@@ -1,0 +1,12 @@
+package org.jarling.models.hooks;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(onlyExplicitlyIncluded = true, callSuper = true)
+public class DirectDebitCreditEvent extends TransactionEvent{
+    private String reference;
+}


### PR DESCRIPTION
This adds a new `TransactionEvent` for Direct Debits and Credits

This work is related to [#304](https://github.com/starlingbank/open-integrations-invoicing/pull/324).